### PR TITLE
Bumping version in the Fargate-only cluster example

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ module "ecs_web" {
 ```hcl
 module "ecs_fargate" { 
   source  = "blinkist/airship-ecs-cluster/aws"
-  version = "0.5.0"
+  version = "0.5.1"
 
   name = "${terraform.workspace}-web"
 


### PR DESCRIPTION
Applying it at version `0.5.0` will result in the following error: `..."owners": required field is not set`